### PR TITLE
Add targets for older .NET Framework versions

### DIFF
--- a/src/DspAdpcm/Adpcm/Decode.cs
+++ b/src/DspAdpcm/Adpcm/Decode.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using static DspAdpcm.Helpers;
-using System.Threading.Tasks;
 using DspAdpcm.Pcm;
+
+#if !NOPARALLEL
+using System.Threading.Tasks;
+#endif
 
 namespace DspAdpcm.Adpcm
 {
@@ -36,6 +39,7 @@ namespace DspAdpcm.Adpcm
             return pcm;
         }
 
+#if !NOPARALLEL
         /// <summary>
         /// Decodes an <see cref="AdpcmStream"/> to a <see cref="PcmStream"/>.
         /// Each channel will be decoded in parallel.
@@ -59,6 +63,7 @@ namespace DspAdpcm.Adpcm
 
             return pcm;
         }
+#endif
 
         private static PcmChannel AdpcmtoPcm(AdpcmChannel adpcmChannel)
         {
@@ -214,7 +219,14 @@ namespace DspAdpcm.Adpcm
 
         internal static void CalculateLoopContext(IEnumerable<AdpcmChannel> channels, int loopStart)
         {
+#if !NOPARALLEL
             Parallel.ForEach(channels, channel => CalculateLoopContext(channel, loopStart));
+#else
+            foreach (AdpcmChannel channel in channels)
+            {
+                CalculateLoopContext(channel, loopStart);
+            }
+#endif
         }
 
         internal static void CalculateLoopContext(this AdpcmChannel audio, int loopStart)
@@ -244,7 +256,14 @@ namespace DspAdpcm.Adpcm
 
         internal static void CalculateSeekTable(IEnumerable<AdpcmChannel> channels, int samplesPerEntry)
         {
+#if !NOPARALLEL
             Parallel.ForEach(channels, channel => CalculateSeekTable(channel, samplesPerEntry));
+#else
+            foreach (AdpcmChannel channel in channels)
+            {
+                CalculateSeekTable(channel, samplesPerEntry);
+            }
+#endif
         }
 
         internal static byte[] BuildSeekTable(IEnumerable<AdpcmChannel> channels, int samplesPerEntry, int numEntries, Endianness endianness)
@@ -264,7 +283,14 @@ namespace DspAdpcm.Adpcm
 
         internal static void CalculateLoopAlignment(IEnumerable<AdpcmChannel> channels, int alignment, int loopStart, int loopEnd)
         {
+#if !NOPARALLEL
             Parallel.ForEach(channels, channel => CalculateLoopAlignment(channel, alignment, loopStart, loopEnd));
+#else
+            foreach (AdpcmChannel channel in channels)
+            {
+                CalculateLoopAlignment(channel, alignment, loopStart, loopEnd);
+            }
+#endif
         }
 
         internal static void CalculateLoopAlignment(this AdpcmChannel audio, int alignment, int loopStart, int loopEnd)

--- a/src/DspAdpcm/Adpcm/Decode.cs
+++ b/src/DspAdpcm/Adpcm/Decode.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using static DspAdpcm.Helpers;
 using DspAdpcm.Pcm;
-
-#if !NOPARALLEL
-using System.Threading.Tasks;
-#endif
 
 namespace DspAdpcm.Adpcm
 {
@@ -219,14 +216,7 @@ namespace DspAdpcm.Adpcm
 
         internal static void CalculateLoopContext(IEnumerable<AdpcmChannel> channels, int loopStart)
         {
-#if !NOPARALLEL
             Parallel.ForEach(channels, channel => CalculateLoopContext(channel, loopStart));
-#else
-            foreach (AdpcmChannel channel in channels)
-            {
-                CalculateLoopContext(channel, loopStart);
-            }
-#endif
         }
 
         internal static void CalculateLoopContext(this AdpcmChannel audio, int loopStart)
@@ -256,14 +246,7 @@ namespace DspAdpcm.Adpcm
 
         internal static void CalculateSeekTable(IEnumerable<AdpcmChannel> channels, int samplesPerEntry)
         {
-#if !NOPARALLEL
             Parallel.ForEach(channels, channel => CalculateSeekTable(channel, samplesPerEntry));
-#else
-            foreach (AdpcmChannel channel in channels)
-            {
-                CalculateSeekTable(channel, samplesPerEntry);
-            }
-#endif
         }
 
         internal static byte[] BuildSeekTable(IEnumerable<AdpcmChannel> channels, int samplesPerEntry, int numEntries, Endianness endianness)
@@ -283,14 +266,7 @@ namespace DspAdpcm.Adpcm
 
         internal static void CalculateLoopAlignment(IEnumerable<AdpcmChannel> channels, int alignment, int loopStart, int loopEnd)
         {
-#if !NOPARALLEL
             Parallel.ForEach(channels, channel => CalculateLoopAlignment(channel, alignment, loopStart, loopEnd));
-#else
-            foreach (AdpcmChannel channel in channels)
-            {
-                CalculateLoopAlignment(channel, alignment, loopStart, loopEnd);
-            }
-#endif
         }
 
         internal static void CalculateLoopAlignment(this AdpcmChannel audio, int alignment, int loopStart, int loopEnd)

--- a/src/DspAdpcm/Adpcm/Encode.cs
+++ b/src/DspAdpcm/Adpcm/Encode.cs
@@ -5,9 +5,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using DspAdpcm.Pcm;
 using static DspAdpcm.Helpers;
+
+#if !NOPARALLEL
+using System.Threading.Tasks;
+#endif
 
 namespace DspAdpcm.Adpcm
 {
@@ -590,6 +593,7 @@ namespace DspAdpcm.Adpcm
             return adpcm;
         }
 
+#if !NOPARALLEL
         /// <summary>
         /// Encodes a <see cref="PcmStream"/> to a <see cref="AdpcmStream"/>.
         /// Each channel will be encoded in parallel.
@@ -613,6 +617,7 @@ namespace DspAdpcm.Adpcm
 
             return adpcm;
         }
+#endif
 
         internal static byte[] EncodeAdpcm(short[] pcm, short[] coefs, short hist1, short hist2, int samples)
         {

--- a/src/DspAdpcm/Adpcm/Encode.cs
+++ b/src/DspAdpcm/Adpcm/Encode.cs
@@ -5,12 +5,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using DspAdpcm.Pcm;
 using static DspAdpcm.Helpers;
-
-#if !NOPARALLEL
-using System.Threading.Tasks;
-#endif
 
 namespace DspAdpcm.Adpcm
 {

--- a/src/DspAdpcm/Adpcm/Formats/Brstm.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Brstm.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using DspAdpcm.Adpcm.Formats.Configuration;
 using DspAdpcm.Adpcm.Formats.Structures;
+using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats
@@ -200,7 +201,7 @@ namespace DspAdpcm.Adpcm.Formats
 
             RecalculateData();
 
-            using (BinaryWriter writer = new BinaryWriterBE(stream, Encoding.UTF8, true))
+            using (BinaryWriter writer = GetStream.GetBinaryWriterBE(stream))
             {
                 stream.Position = 0;
                 GetRstmHeader(writer);
@@ -355,7 +356,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static BrstmStructure ReadBrstmFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = new BinaryReaderBE(stream, Encoding.UTF8, true))
+            using (BinaryReader reader = GetStream.GetBinaryReaderBE(stream))
             {
                 if (Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4) != "RSTM")
                 {

--- a/src/DspAdpcm/Adpcm/Formats/Brstm.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Brstm.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using DspAdpcm.Adpcm.Formats.Configuration;
 using DspAdpcm.Adpcm.Formats.Structures;
-using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats
@@ -201,7 +200,7 @@ namespace DspAdpcm.Adpcm.Formats
 
             RecalculateData();
 
-            using (BinaryWriter writer = GetStream.GetBinaryWriterBE(stream))
+            using (BinaryWriter writer = GetBinaryWriterBE(stream))
             {
                 stream.Position = 0;
                 GetRstmHeader(writer);
@@ -356,7 +355,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static BrstmStructure ReadBrstmFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetStream.GetBinaryReaderBE(stream))
+            using (BinaryReader reader = GetBinaryReaderBE(stream))
             {
                 if (Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4) != "RSTM")
                 {

--- a/src/DspAdpcm/Adpcm/Formats/Brstm.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Brstm.cs
@@ -200,7 +200,7 @@ namespace DspAdpcm.Adpcm.Formats
 
             RecalculateData();
 
-            using (BinaryWriter writer = GetBinaryWriterBE(stream))
+            using (BinaryWriter writer = GetBinaryWriter(stream, Endianness.BigEndian))
             {
                 stream.Position = 0;
                 GetRstmHeader(writer);
@@ -355,7 +355,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static BrstmStructure ReadBrstmFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetBinaryReaderBE(stream))
+            using (BinaryReader reader = GetBinaryReader(stream, Endianness.BigEndian))
             {
                 if (Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4) != "RSTM")
                 {

--- a/src/DspAdpcm/Adpcm/Formats/Dsp.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Dsp.cs
@@ -168,7 +168,7 @@ namespace DspAdpcm.Adpcm.Formats
 
             RecalculateData();
 
-            using (BinaryWriter writer = GetBinaryWriterBE(stream))
+            using (BinaryWriter writer = GetBinaryWriter(stream, Endianness.BigEndian))
             {
                 stream.Position = 0;
                 GetHeader(writer);
@@ -219,7 +219,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static DspStructure ReadDspFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetBinaryReaderBE(stream))
+            using (BinaryReader reader = GetBinaryReader(stream, Endianness.BigEndian))
             {
                 var structure = new DspStructure();
 

--- a/src/DspAdpcm/Adpcm/Formats/Dsp.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Dsp.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using DspAdpcm.Adpcm.Formats.Configuration;
 using DspAdpcm.Adpcm.Formats.Structures;
+using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats
@@ -169,7 +169,7 @@ namespace DspAdpcm.Adpcm.Formats
 
             RecalculateData();
 
-            using (BinaryWriter writer = new BinaryWriterBE(stream, Encoding.UTF8, true))
+            using (BinaryWriter writer = GetStream.GetBinaryWriterBE(stream))
             {
                 stream.Position = 0;
                 GetHeader(writer);
@@ -220,7 +220,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static DspStructure ReadDspFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = new BinaryReaderBE(stream, Encoding.UTF8, true))
+            using (BinaryReader reader = GetStream.GetBinaryReaderBE(stream))
             {
                 var structure = new DspStructure();
 

--- a/src/DspAdpcm/Adpcm/Formats/Dsp.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Dsp.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using DspAdpcm.Adpcm.Formats.Configuration;
 using DspAdpcm.Adpcm.Formats.Structures;
-using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats
@@ -169,7 +168,7 @@ namespace DspAdpcm.Adpcm.Formats
 
             RecalculateData();
 
-            using (BinaryWriter writer = GetStream.GetBinaryWriterBE(stream))
+            using (BinaryWriter writer = GetBinaryWriterBE(stream))
             {
                 stream.Position = 0;
                 GetHeader(writer);
@@ -220,7 +219,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static DspStructure ReadDspFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetStream.GetBinaryReaderBE(stream))
+            using (BinaryReader reader = GetBinaryReaderBE(stream))
             {
                 var structure = new DspStructure();
 

--- a/src/DspAdpcm/Adpcm/Formats/Genh.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Genh.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Text;
 using DspAdpcm.Adpcm.Formats.Structures;
+using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats
@@ -69,7 +69,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static GenhStructure ReadGenhFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (BinaryReader reader = GetStream.GetBinaryReader(stream))
             {
                 var structure = new GenhStructure();
 
@@ -151,8 +151,8 @@ namespace DspAdpcm.Adpcm.Formats
         private static void ReadCoefs(BinaryReader reader, GenhStructure structure, int channelNum)
         {
             using (BinaryReader coefReader = structure.CoefType.HasFlag(GenhCoefType.LittleEndian)
-                ? new BinaryReader(reader.BaseStream, Encoding.UTF8, true)
-                : new BinaryReaderBE(reader.BaseStream, Encoding.UTF8, true))
+                ? GetStream.GetBinaryReader(reader.BaseStream)
+                : GetStream.GetBinaryReaderBE(reader.BaseStream))
             {
                 coefReader.BaseStream.Position = structure.Coefs[channelNum];
                 var channel = new AdpcmChannelInfo();

--- a/src/DspAdpcm/Adpcm/Formats/Genh.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Genh.cs
@@ -68,7 +68,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static GenhStructure ReadGenhFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetBinaryReader(stream))
+            using (BinaryReader reader = GetBinaryReader(stream, Endianness.LittleEndian))
             {
                 var structure = new GenhStructure();
 
@@ -149,9 +149,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static void ReadCoefs(BinaryReader reader, GenhStructure structure, int channelNum)
         {
-            using (BinaryReader coefReader = structure.CoefType.HasFlag(GenhCoefType.LittleEndian)
-                ? GetBinaryReader(reader.BaseStream)
-                : GetBinaryReaderBE(reader.BaseStream))
+            using (BinaryReader coefReader = GetBinaryReader(reader.BaseStream, structure.CoefType.Endianness()))
             {
                 coefReader.BaseStream.Position = structure.Coefs[channelNum];
                 var channel = new AdpcmChannelInfo();

--- a/src/DspAdpcm/Adpcm/Formats/Genh.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Genh.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Text;
 using DspAdpcm.Adpcm.Formats.Structures;
-using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats
@@ -69,7 +68,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static GenhStructure ReadGenhFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetStream.GetBinaryReader(stream))
+            using (BinaryReader reader = GetBinaryReader(stream))
             {
                 var structure = new GenhStructure();
 
@@ -151,8 +150,8 @@ namespace DspAdpcm.Adpcm.Formats
         private static void ReadCoefs(BinaryReader reader, GenhStructure structure, int channelNum)
         {
             using (BinaryReader coefReader = structure.CoefType.HasFlag(GenhCoefType.LittleEndian)
-                ? GetStream.GetBinaryReader(reader.BaseStream)
-                : GetStream.GetBinaryReaderBE(reader.BaseStream))
+                ? GetBinaryReader(reader.BaseStream)
+                : GetBinaryReaderBE(reader.BaseStream))
             {
                 coefReader.BaseStream.Position = structure.Coefs[channelNum];
                 var channel = new AdpcmChannelInfo();

--- a/src/DspAdpcm/Adpcm/Formats/Idsp.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Idsp.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using DspAdpcm.Adpcm.Formats.Configuration;
 using DspAdpcm.Adpcm.Formats.Structures;
-using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats
@@ -171,7 +170,7 @@ namespace DspAdpcm.Adpcm.Formats
 
             RecalculateData();
 
-            using (BinaryWriter writer = GetStream.GetBinaryWriterBE(stream))
+            using (BinaryWriter writer = GetBinaryWriterBE(stream))
             {
                 stream.Position = 0;
                 GetHeader(writer);
@@ -228,7 +227,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static IdspStructure ReadIdspFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetStream.GetBinaryReaderBE(stream))
+            using (BinaryReader reader = GetBinaryReaderBE(stream))
             {
                 if (Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4) != "IDSP")
                 {

--- a/src/DspAdpcm/Adpcm/Formats/Idsp.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Idsp.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using DspAdpcm.Adpcm.Formats.Configuration;
 using DspAdpcm.Adpcm.Formats.Structures;
+using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats
@@ -170,7 +171,7 @@ namespace DspAdpcm.Adpcm.Formats
 
             RecalculateData();
 
-            using (BinaryWriter writer = new BinaryWriterBE(stream, Encoding.UTF8, true))
+            using (BinaryWriter writer = GetStream.GetBinaryWriterBE(stream))
             {
                 stream.Position = 0;
                 GetHeader(writer);
@@ -227,7 +228,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static IdspStructure ReadIdspFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = new BinaryReaderBE(stream, Encoding.UTF8, true))
+            using (BinaryReader reader = GetStream.GetBinaryReaderBE(stream))
             {
                 if (Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4) != "IDSP")
                 {

--- a/src/DspAdpcm/Adpcm/Formats/Idsp.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Idsp.cs
@@ -170,7 +170,7 @@ namespace DspAdpcm.Adpcm.Formats
 
             RecalculateData();
 
-            using (BinaryWriter writer = GetBinaryWriterBE(stream))
+            using (BinaryWriter writer = GetBinaryWriter(stream, Endianness.BigEndian))
             {
                 stream.Position = 0;
                 GetHeader(writer);
@@ -227,7 +227,7 @@ namespace DspAdpcm.Adpcm.Formats
 
         private static IdspStructure ReadIdspFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetBinaryReaderBE(stream))
+            using (BinaryReader reader = GetBinaryReader(stream, Endianness.BigEndian))
             {
                 if (Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4) != "IDSP")
                 {

--- a/src/DspAdpcm/Adpcm/Formats/Internal/BCFstm.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Internal/BCFstm.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using DspAdpcm.Adpcm.Formats.Structures;
+using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats.Internal
@@ -135,8 +136,8 @@ namespace DspAdpcm.Adpcm.Formats.Internal
             RecalculateData();
 
             using (BinaryWriter writer = endianness == Endianness.LittleEndian ?
-                new BinaryWriter(stream, Encoding.UTF8, true) :
-                new BinaryWriterBE(stream, Encoding.UTF8, true))
+                GetStream.GetBinaryWriter(stream) :
+                GetStream.GetBinaryWriterBE(stream))
             {
                 stream.Position = 0;
                 GetHeader(writer, type);
@@ -332,7 +333,7 @@ namespace DspAdpcm.Adpcm.Formats.Internal
         internal static BCFstmStructure ReadBCFstmFile(Stream stream, bool readAudioData = true)
         {
             BCFstmType type;
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (BinaryReader reader = GetStream.GetBinaryReader(stream))
             {
                 string magic = Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4);
                 switch (magic)
@@ -349,8 +350,8 @@ namespace DspAdpcm.Adpcm.Formats.Internal
             }
 
             using (BinaryReader reader = type == BCFstmType.Bcstm ?
-                new BinaryReader(stream, Encoding.UTF8, true) :
-                new BinaryReaderBE(stream, Encoding.UTF8, true))
+                GetStream.GetBinaryReader(stream) :
+                GetStream.GetBinaryReaderBE(stream))
             {
                 BCFstmStructure structure = new BcstmStructure();
 

--- a/src/DspAdpcm/Adpcm/Formats/Internal/BCFstm.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Internal/BCFstm.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using DspAdpcm.Adpcm.Formats.Structures;
-using DspAdpcm.Compatibility;
 using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Adpcm.Formats.Internal
@@ -136,8 +135,8 @@ namespace DspAdpcm.Adpcm.Formats.Internal
             RecalculateData();
 
             using (BinaryWriter writer = endianness == Endianness.LittleEndian ?
-                GetStream.GetBinaryWriter(stream) :
-                GetStream.GetBinaryWriterBE(stream))
+                GetBinaryWriter(stream) :
+                GetBinaryWriterBE(stream))
             {
                 stream.Position = 0;
                 GetHeader(writer, type);
@@ -333,7 +332,7 @@ namespace DspAdpcm.Adpcm.Formats.Internal
         internal static BCFstmStructure ReadBCFstmFile(Stream stream, bool readAudioData = true)
         {
             BCFstmType type;
-            using (BinaryReader reader = GetStream.GetBinaryReader(stream))
+            using (BinaryReader reader = GetBinaryReader(stream))
             {
                 string magic = Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4);
                 switch (magic)
@@ -350,8 +349,8 @@ namespace DspAdpcm.Adpcm.Formats.Internal
             }
 
             using (BinaryReader reader = type == BCFstmType.Bcstm ?
-                GetStream.GetBinaryReader(stream) :
-                GetStream.GetBinaryReaderBE(stream))
+                GetBinaryReader(stream) :
+                GetBinaryReaderBE(stream))
             {
                 BCFstmStructure structure = new BcstmStructure();
 

--- a/src/DspAdpcm/Adpcm/Formats/Internal/BCFstm.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Internal/BCFstm.cs
@@ -130,18 +130,14 @@ namespace DspAdpcm.Adpcm.Formats.Internal
                 }
             }
 
-            Endianness endianness = type == BCFstmType.Bcstm ? Endianness.LittleEndian : Endianness.BigEndian;
-
             RecalculateData();
 
-            using (BinaryWriter writer = endianness == Endianness.LittleEndian ?
-                GetBinaryWriter(stream) :
-                GetBinaryWriterBE(stream))
+            using (BinaryWriter writer = GetBinaryWriter(stream, GetTypeEndianess(type)))
             {
                 stream.Position = 0;
                 GetHeader(writer, type);
                 stream.Position = InfoChunkOffset;
-                GetInfoChunk(writer, endianness);
+                GetInfoChunk(writer, GetTypeEndianess(type));
                 stream.Position = SeekChunkOffset;
                 GetSeekChunk(writer);
                 stream.Position = DataChunkOffset;
@@ -332,7 +328,7 @@ namespace DspAdpcm.Adpcm.Formats.Internal
         internal static BCFstmStructure ReadBCFstmFile(Stream stream, bool readAudioData = true)
         {
             BCFstmType type;
-            using (BinaryReader reader = GetBinaryReader(stream))
+            using (BinaryReader reader = GetBinaryReader(stream, Endianness.LittleEndian))
             {
                 string magic = Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4);
                 switch (magic)
@@ -348,9 +344,7 @@ namespace DspAdpcm.Adpcm.Formats.Internal
                 }
             }
 
-            using (BinaryReader reader = type == BCFstmType.Bcstm ?
-                GetBinaryReader(stream) :
-                GetBinaryReaderBE(stream))
+            using (BinaryReader reader = GetBinaryReader(stream, GetTypeEndianess(type)))
             {
                 BCFstmStructure structure = new BcstmStructure();
 
@@ -651,6 +645,9 @@ namespace DspAdpcm.Adpcm.Formats.Internal
             Bcstm,
             Bfstm
         }
+
+        private static Endianness GetTypeEndianess(BCFstmType type) =>
+            type == BCFstmType.Bcstm ? Endianness.LittleEndian : Endianness.BigEndian;
     }
 
     internal class BCFstmConfiguration : B_stmConfiguration

--- a/src/DspAdpcm/Adpcm/Formats/Structures/GenhStructure.cs
+++ b/src/DspAdpcm/Adpcm/Formats/Structures/GenhStructure.cs
@@ -91,4 +91,12 @@ namespace DspAdpcm.Adpcm.Formats.Structures
         /// </summary>
         LittleEndian = 2
     }
+
+    internal static class GenhCoefTypeExtension
+    {
+        public static Helpers.Endianness Endianness(this GenhCoefType coefType) =>
+            coefType.HasFlag(GenhCoefType.LittleEndian)
+                ? Helpers.Endianness.LittleEndian
+                : Helpers.Endianness.BigEndian;
+    }
 }

--- a/src/DspAdpcm/BinaryReaderBE.cs
+++ b/src/DspAdpcm/BinaryReaderBE.cs
@@ -8,7 +8,7 @@ namespace DspAdpcm
     {
         public BinaryReaderBE(Stream input) : base(input) { }
 
-#if !(NET35 || NET40)
+#if !(NET20 || NET35 || NET40)
         public BinaryReaderBE(Stream input, Encoding encoding, bool leaveOpen) : base(input, encoding, leaveOpen) { }
 #endif
 

--- a/src/DspAdpcm/BinaryReaderBE.cs
+++ b/src/DspAdpcm/BinaryReaderBE.cs
@@ -8,7 +8,9 @@ namespace DspAdpcm
     {
         public BinaryReaderBE(Stream input) : base(input) { }
 
+#if !NET40
         public BinaryReaderBE(Stream input, Encoding encoding, bool leaveOpen) : base(input, encoding, leaveOpen) { }
+#endif
 
         public override short ReadInt16()
         {

--- a/src/DspAdpcm/BinaryReaderBE.cs
+++ b/src/DspAdpcm/BinaryReaderBE.cs
@@ -8,7 +8,7 @@ namespace DspAdpcm
     {
         public BinaryReaderBE(Stream input) : base(input) { }
 
-#if !NET40
+#if !(NET35 || NET40)
         public BinaryReaderBE(Stream input, Encoding encoding, bool leaveOpen) : base(input, encoding, leaveOpen) { }
 #endif
 

--- a/src/DspAdpcm/BinaryWriterBE.cs
+++ b/src/DspAdpcm/BinaryWriterBE.cs
@@ -7,7 +7,7 @@ namespace DspAdpcm
     {
         public BinaryWriterBE(Stream input) : base(input) { }
 
-#if !(NET35 || NET40)
+#if !(NET20 || NET35 || NET40)
         public BinaryWriterBE(Stream output, Encoding encoding, bool leaveOpen) : base(output, encoding, leaveOpen) { }
 #endif
 

--- a/src/DspAdpcm/BinaryWriterBE.cs
+++ b/src/DspAdpcm/BinaryWriterBE.cs
@@ -7,7 +7,7 @@ namespace DspAdpcm
     {
         public BinaryWriterBE(Stream input) : base(input) { }
 
-#if !NET40
+#if !(NET35 || NET40)
         public BinaryWriterBE(Stream output, Encoding encoding, bool leaveOpen) : base(output, encoding, leaveOpen) { }
 #endif
 

--- a/src/DspAdpcm/BinaryWriterBE.cs
+++ b/src/DspAdpcm/BinaryWriterBE.cs
@@ -7,7 +7,9 @@ namespace DspAdpcm
     {
         public BinaryWriterBE(Stream input) : base(input) { }
 
+#if !NET40
         public BinaryWriterBE(Stream output, Encoding encoding, bool leaveOpen) : base(output, encoding, leaveOpen) { }
+#endif
 
         private readonly byte[] _buffer = new byte[16];
 

--- a/src/DspAdpcm/Compatibility/EnumFlag.cs
+++ b/src/DspAdpcm/Compatibility/EnumFlag.cs
@@ -1,0 +1,27 @@
+﻿#if NET35
+using System;
+
+namespace DspAdpcm.Compatibility
+{
+    internal static class EnumFlag
+    {
+        public static bool HasFlag(this Enum variable, Enum value)
+        {
+            if (variable == null)
+                return false;
+
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            if (!Enum.IsDefined(variable.GetType(), value))
+            {
+                throw new ArgumentException(
+                    $"Enumeration type mismatch.  The flag is of type '{value.GetType()}', was expecting '{variable.GetType()}'.");
+            }
+
+            ulong num = Convert.ToUInt64(value);
+            return ((Convert.ToUInt64(variable) & num) == num);
+        }
+    }
+}
+#endif

--- a/src/DspAdpcm/Compatibility/EnumFlag.cs
+++ b/src/DspAdpcm/Compatibility/EnumFlag.cs
@@ -1,4 +1,4 @@
-﻿#if NET35
+﻿#if NET20 || NET35
 using System;
 
 namespace DspAdpcm.Compatibility

--- a/src/DspAdpcm/Compatibility/EnumFlag.cs
+++ b/src/DspAdpcm/Compatibility/EnumFlag.cs
@@ -1,7 +1,8 @@
 ﻿#if NET20 || NET35
 using System;
 
-namespace DspAdpcm.Compatibility
+// ReSharper disable once CheckNamespace
+namespace DspAdpcm
 {
     internal static class EnumFlag
     {

--- a/src/DspAdpcm/Compatibility/Extensions.cs
+++ b/src/DspAdpcm/Compatibility/Extensions.cs
@@ -1,0 +1,7 @@
+﻿#if NET20
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
+    internal sealed class ExtensionAttribute : Attribute { }
+}
+#endif

--- a/src/DspAdpcm/Compatibility/Parallel.cs
+++ b/src/DspAdpcm/Compatibility/Parallel.cs
@@ -1,0 +1,39 @@
+﻿#if NOPARALLEL
+using System.Collections.Generic;
+
+namespace System.Threading.Tasks
+{
+    internal static class Parallel
+    {
+        public static void ForEach<TSource>(IEnumerable<TSource> source, Action<TSource> body)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (body == null)
+            {
+                throw new ArgumentNullException(nameof(body));
+            }
+
+            foreach (TSource item in source)
+            {
+                body(item);
+            }
+        }
+
+        public static void For(int fromInclusive, int toExclusive, Action<int> body)
+        {
+            if (body == null)
+            {
+                throw new ArgumentNullException(nameof(body));
+            }
+
+            for (int i = fromInclusive; i < toExclusive; i++)
+            {
+                body(i);
+            }
+        }
+    }
+}
+#endif

--- a/src/DspAdpcm/Compatibility/Stream.cs
+++ b/src/DspAdpcm/Compatibility/Stream.cs
@@ -1,0 +1,49 @@
+﻿using System.IO;
+using System.Text;
+
+namespace DspAdpcm.Compatibility
+{
+    internal static class GetStream
+    {
+#if !NET40
+        public static BinaryReader GetBinaryReader(Stream stream) => new BinaryReader(stream, Encoding.UTF8, true);
+        public static BinaryReaderBE GetBinaryReaderBE(Stream stream) => new BinaryReaderBE(stream, Encoding.UTF8, true);
+        public static BinaryWriter GetBinaryWriter(Stream stream) => new BinaryWriter(stream, Encoding.UTF8, true);
+        public static BinaryWriterBE GetBinaryWriterBE(Stream stream) => new BinaryWriterBE(stream, Encoding.UTF8, true);
+#else
+        public static BinaryReader GetBinaryReader(Stream stream) => new BinaryReader(new StreamNoDispose(stream));
+        public static BinaryReaderBE GetBinaryReaderBE(Stream stream) => new BinaryReaderBE(new StreamNoDispose(stream));
+        public static BinaryWriter GetBinaryWriter(Stream stream) => new BinaryWriter(new StreamNoDispose(stream));
+        public static BinaryWriterBE GetBinaryWriterBE(Stream stream) => new BinaryWriterBE(new StreamNoDispose(stream));
+#endif
+    }
+
+#if NET40
+    internal sealed class StreamNoDispose : Stream
+    {
+        private Stream BaseStream { get; }
+
+        public StreamNoDispose(Stream baseStream)
+        {
+            BaseStream = baseStream;
+        }
+
+        public override long Position
+        {
+            get { return BaseStream.Position; }
+            set { BaseStream.Position = value; }
+        }
+
+        public override void Flush() => BaseStream.Flush();
+        public override void Close() => BaseStream.Flush();
+        public override bool CanRead => BaseStream.CanRead;
+        public override bool CanSeek => BaseStream.CanSeek;
+        public override bool CanWrite => BaseStream.CanWrite;
+        public override long Length => BaseStream.Length;
+        public override void Write(byte[] buffer, int offset, int count) => BaseStream.Write(buffer, offset, count);
+        public override void SetLength(long value) => BaseStream.SetLength(value);
+        public override long Seek(long offset, SeekOrigin origin) => BaseStream.Seek(offset, origin);
+        public override int Read(byte[] buffer, int offset, int count) => BaseStream.Read(buffer, offset, count);
+    }
+#endif
+}

--- a/src/DspAdpcm/Compatibility/Stream.cs
+++ b/src/DspAdpcm/Compatibility/Stream.cs
@@ -5,7 +5,7 @@ namespace DspAdpcm.Compatibility
 {
     internal static class GetStream
     {
-#if !(NET35 || NET40)
+#if !(NET20 || NET35 || NET40)
         public static BinaryReader GetBinaryReader(Stream stream) => new BinaryReader(stream, Encoding.UTF8, true);
         public static BinaryReaderBE GetBinaryReaderBE(Stream stream) => new BinaryReaderBE(stream, Encoding.UTF8, true);
         public static BinaryWriter GetBinaryWriter(Stream stream) => new BinaryWriter(stream, Encoding.UTF8, true);
@@ -18,7 +18,7 @@ namespace DspAdpcm.Compatibility
 #endif
     }
 
-#if NET35 || NET40
+#if NET20 || NET35 || NET40
     internal sealed class StreamNoDispose : Stream
     {
         private Stream BaseStream { get; }

--- a/src/DspAdpcm/Compatibility/Stream.cs
+++ b/src/DspAdpcm/Compatibility/Stream.cs
@@ -5,7 +5,7 @@ namespace DspAdpcm.Compatibility
 {
     internal static class GetStream
     {
-#if !NET40
+#if !(NET35 || NET40)
         public static BinaryReader GetBinaryReader(Stream stream) => new BinaryReader(stream, Encoding.UTF8, true);
         public static BinaryReaderBE GetBinaryReaderBE(Stream stream) => new BinaryReaderBE(stream, Encoding.UTF8, true);
         public static BinaryWriter GetBinaryWriter(Stream stream) => new BinaryWriter(stream, Encoding.UTF8, true);
@@ -18,7 +18,7 @@ namespace DspAdpcm.Compatibility
 #endif
     }
 
-#if NET40
+#if NET35 || NET40
     internal sealed class StreamNoDispose : Stream
     {
         private Stream BaseStream { get; }

--- a/src/DspAdpcm/Compatibility/Tuple.cs
+++ b/src/DspAdpcm/Compatibility/Tuple.cs
@@ -1,4 +1,4 @@
-﻿#if NET35
+﻿#if NET20 || NET35
 namespace System
 {
     internal class Tuple<T1, T2, T3>

--- a/src/DspAdpcm/Compatibility/Tuple.cs
+++ b/src/DspAdpcm/Compatibility/Tuple.cs
@@ -1,0 +1,18 @@
+﻿#if NET35
+namespace System
+{
+    internal class Tuple<T1, T2, T3>
+    {
+        public T1 Item1 { get; }
+        public T2 Item2 { get; }
+        public T3 Item3 { get; }
+
+        public Tuple(T1 item1, T2 item2, T3 item3)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+        }
+    }
+}
+#endif

--- a/src/DspAdpcm/DspAdpcm.csproj
+++ b/src/DspAdpcm/DspAdpcm.csproj
@@ -69,6 +69,7 @@
     <Compile Include="BinaryReaderBE.cs" />
     <Compile Include="BinaryWriterBE.cs" />
     <Compile Include="Compatibility\EnumFlag.cs" />
+    <Compile Include="Compatibility\Extensions.cs" />
     <Compile Include="Compatibility\Stream.cs" />
     <Compile Include="Compatibility\Tuple.cs" />
     <Compile Include="Helpers.cs" />

--- a/src/DspAdpcm/DspAdpcm.csproj
+++ b/src/DspAdpcm/DspAdpcm.csproj
@@ -70,6 +70,7 @@
     <Compile Include="BinaryWriterBE.cs" />
     <Compile Include="Compatibility\EnumFlag.cs" />
     <Compile Include="Compatibility\Extensions.cs" />
+    <Compile Include="Compatibility\Parallel.cs" />
     <Compile Include="Compatibility\Stream.cs" />
     <Compile Include="Compatibility\Tuple.cs" />
     <Compile Include="Helpers.cs" />

--- a/src/DspAdpcm/DspAdpcm.csproj
+++ b/src/DspAdpcm/DspAdpcm.csproj
@@ -68,7 +68,9 @@
     <Compile Include="Adpcm\Formats\Structures\IdspStructure.cs" />
     <Compile Include="BinaryReaderBE.cs" />
     <Compile Include="BinaryWriterBE.cs" />
+    <Compile Include="Compatibility\EnumFlag.cs" />
     <Compile Include="Compatibility\Stream.cs" />
+    <Compile Include="Compatibility\Tuple.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Adpcm\Formats\Dsp.cs" />

--- a/src/DspAdpcm/DspAdpcm.csproj
+++ b/src/DspAdpcm/DspAdpcm.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Adpcm\Formats\Structures\IdspStructure.cs" />
     <Compile Include="BinaryReaderBE.cs" />
     <Compile Include="BinaryWriterBE.cs" />
+    <Compile Include="Compatibility\Stream.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Adpcm\Formats\Dsp.cs" />

--- a/src/DspAdpcm/Helpers.cs
+++ b/src/DspAdpcm/Helpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using DspAdpcm.Compatibility;
 
 namespace DspAdpcm
 {
@@ -91,5 +92,13 @@ namespace DspAdpcm
             BigEndian,
             LittleEndian
         }
+
+        public static BinaryReader GetBinaryReader(Stream stream) => GetStream.GetBinaryReader(stream);
+
+        public static BinaryReaderBE GetBinaryReaderBE(Stream stream) => GetStream.GetBinaryReaderBE(stream);
+
+        public static BinaryWriter GetBinaryWriter(Stream stream) => GetStream.GetBinaryWriter(stream);
+
+        public static BinaryWriterBE GetBinaryWriterBE(Stream stream) => GetStream.GetBinaryWriterBE(stream);
     }
 }

--- a/src/DspAdpcm/Helpers.cs
+++ b/src/DspAdpcm/Helpers.cs
@@ -50,7 +50,7 @@ namespace DspAdpcm
             return BytesPerFrame * frames + extraBytes;
         }
 
-#if !NET40
+#if !(NET35 || NET40)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
         public static short Clamp16(int value)

--- a/src/DspAdpcm/Helpers.cs
+++ b/src/DspAdpcm/Helpers.cs
@@ -50,7 +50,7 @@ namespace DspAdpcm
             return BytesPerFrame * frames + extraBytes;
         }
 
-#if !(NET35 || NET40)
+#if !(NET20 || NET35 || NET40)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
         public static short Clamp16(int value)

--- a/src/DspAdpcm/Helpers.cs
+++ b/src/DspAdpcm/Helpers.cs
@@ -93,12 +93,14 @@ namespace DspAdpcm
             LittleEndian
         }
 
-        public static BinaryReader GetBinaryReader(Stream stream) => GetStream.GetBinaryReader(stream);
+        public static BinaryReader GetBinaryReader(Stream stream, Endianness endianness) =>
+            endianness == Endianness.LittleEndian
+                ? GetStream.GetBinaryReader(stream)
+                : GetStream.GetBinaryReaderBE(stream);
 
-        public static BinaryReaderBE GetBinaryReaderBE(Stream stream) => GetStream.GetBinaryReaderBE(stream);
-
-        public static BinaryWriter GetBinaryWriter(Stream stream) => GetStream.GetBinaryWriter(stream);
-
-        public static BinaryWriterBE GetBinaryWriterBE(Stream stream) => GetStream.GetBinaryWriterBE(stream);
+        public static BinaryWriter GetBinaryWriter(Stream stream, Endianness endianness) =>
+            endianness == Endianness.LittleEndian
+                ? GetStream.GetBinaryWriter(stream)
+                : GetStream.GetBinaryWriterBE(stream);
     }
 }

--- a/src/DspAdpcm/Helpers.cs
+++ b/src/DspAdpcm/Helpers.cs
@@ -50,7 +50,9 @@ namespace DspAdpcm
             return BytesPerFrame * frames + extraBytes;
         }
 
+#if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static short Clamp16(int value)
         {
             if (value > short.MaxValue)

--- a/src/DspAdpcm/Pcm/Formats/Wave.cs
+++ b/src/DspAdpcm/Pcm/Formats/Wave.cs
@@ -132,7 +132,7 @@ namespace DspAdpcm.Pcm.Formats
                 }
             }
 
-            using (BinaryWriter writer = GetBinaryWriter(stream))
+            using (BinaryWriter writer = GetBinaryWriter(stream, Endianness.LittleEndian))
             {
                 stream.Position = 0;
                 GetRiffHeader(writer);
@@ -203,7 +203,7 @@ namespace DspAdpcm.Pcm.Formats
 
         private static WaveStructure ReadWaveFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetBinaryReader(stream))
+            using (BinaryReader reader = GetBinaryReader(stream, Endianness.LittleEndian))
             {
                 var structure = new WaveStructure();
 

--- a/src/DspAdpcm/Pcm/Formats/Wave.cs
+++ b/src/DspAdpcm/Pcm/Formats/Wave.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using DspAdpcm.Compatibility;
 
 namespace DspAdpcm.Pcm.Formats
 {
@@ -131,7 +132,7 @@ namespace DspAdpcm.Pcm.Formats
                 }
             }
 
-            using (BinaryWriter writer = new BinaryWriter(stream, Encoding.UTF8, true))
+            using (BinaryWriter writer = GetStream.GetBinaryWriter(stream))
             {
                 stream.Position = 0;
                 GetRiffHeader(writer);
@@ -202,7 +203,7 @@ namespace DspAdpcm.Pcm.Formats
 
         private static WaveStructure ReadWaveFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (BinaryReader reader = GetStream.GetBinaryReader(stream))
             {
                 var structure = new WaveStructure();
 

--- a/src/DspAdpcm/Pcm/Formats/Wave.cs
+++ b/src/DspAdpcm/Pcm/Formats/Wave.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
-using DspAdpcm.Compatibility;
+using static DspAdpcm.Helpers;
 
 namespace DspAdpcm.Pcm.Formats
 {
@@ -132,7 +132,7 @@ namespace DspAdpcm.Pcm.Formats
                 }
             }
 
-            using (BinaryWriter writer = GetStream.GetBinaryWriter(stream))
+            using (BinaryWriter writer = GetBinaryWriter(stream))
             {
                 stream.Position = 0;
                 GetRiffHeader(writer);
@@ -203,7 +203,7 @@ namespace DspAdpcm.Pcm.Formats
 
         private static WaveStructure ReadWaveFile(Stream stream, bool readAudioData = true)
         {
-            using (BinaryReader reader = GetStream.GetBinaryReader(stream))
+            using (BinaryReader reader = GetBinaryReader(stream))
             {
                 var structure = new WaveStructure();
 

--- a/src/DspAdpcm/project.json
+++ b/src/DspAdpcm/project.json
@@ -30,6 +30,18 @@
                 "System.Threading.Tasks.Parallel": "4.0.1"
             }
         },
+        "netstandard1.0": {
+            "dependencies": {
+                "System.IO": "4.1.0",
+                "System.Linq": "4.1.0",
+                "System.Resources.ResourceManager": "4.0.1",
+                "System.Runtime": "4.1.0",
+                "System.Runtime.Extensions": "4.1.0"
+            },
+            "buildOptions": {
+                "define": [ "NOPARALLEL" ]
+            }
+        },
         "net45": {},
         "net40": {},
         "net35": {

--- a/src/DspAdpcm/project.json
+++ b/src/DspAdpcm/project.json
@@ -30,18 +30,6 @@
                 "System.Threading.Tasks.Parallel": "4.0.1"
             }
         },
-        "netstandard1.0": {
-            "dependencies": {
-                "System.IO": "4.1.0",
-                "System.Linq": "4.1.0",
-                "System.Resources.ResourceManager": "4.0.1",
-                "System.Runtime": "4.1.0",
-                "System.Runtime.Extensions": "4.1.0"
-            },
-            "buildOptions": {
-                "define": [ "NOPARALLEL" ]
-            }
-        },
         "net45": {},
         "net40": {},
         "net35": {

--- a/src/DspAdpcm/project.json
+++ b/src/DspAdpcm/project.json
@@ -48,6 +48,14 @@
             "buildOptions": {
                 "define": [ "NOPARALLEL" ]
             }
+        },
+        "net20": {
+            "dependencies": {
+                "LinqBridge": "1.3.0"
+            },
+            "buildOptions": {
+                "define": [ "NOPARALLEL" ]
+            }
         }
     }
 }

--- a/src/DspAdpcm/project.json
+++ b/src/DspAdpcm/project.json
@@ -30,6 +30,7 @@
                 "System.Threading.Tasks.Parallel": "4.0.1"
             }
         },
-        "net45": {}
+        "net45": {},
+        "net40": {} 
     }
 }

--- a/src/DspAdpcm/project.json
+++ b/src/DspAdpcm/project.json
@@ -31,6 +31,11 @@
             }
         },
         "net45": {},
-        "net40": {} 
+        "net40": {},
+        "net35": {
+            "buildOptions": {
+                "define": [ "NOPARALLEL" ]
+            }
+        }
     }
 }


### PR DESCRIPTION
Target .NET 4.0, 3.5, and 2.0.
Add backported features as needed.
Add helper functions for getting BinaryReaders and BinaryWriters of the specified endianness.